### PR TITLE
Update build_all.sh

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -1,6 +1,6 @@
 DIR=$(pwd)
 
-cd $DIR/mycpp/ && mkdir -p build && cd build && cmake .. && make -j11
+cd $DIR/mycpp/ && mkdir -p build && cd build && cmake .. -DPYTHON_EXECUTABLE=$(which python) && make -j11
 cd /kaolin && rm -rf build *egg* && pip install -e .
 cd $DIR/bundlesdf/mycuda && rm -rf build *egg* && pip install -e .
 


### PR DESCRIPTION
When using different python version, for example with pyenv, cmake should bind to the currently used python version