### PR TITLE
Fix: Handle empty colors array in toOpen3dCloud

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -280,7 +280,7 @@ def normalizeRotation(pose):
 def toOpen3dCloud(points,colors=None,normals=None):
   cloud = o3d.geometry.PointCloud()
   cloud.points = o3d.utility.Vector3dVector(points.astype(np.float64))
-  if colors is not None:
+  if colors is not None and colors.size > 0:  # Check if colors is not empty:
     if colors.max()>1:
       colors = colors/255.0
     cloud.colors = o3d.utility.Vector3dVector(colors.astype(np.float64))


### PR DESCRIPTION
This pull request fixes an issue where a `ValueError` occurs when the `colors` array is empty in the `toOpen3dCloud` function. The update adds a check to ensure the array is not empty before performing operations, preventing runtime errors and improving code robustness.