### PR TITLE
add glvcam_to_cvcam

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,10 @@ Our training data include scenes using 3D assets from GSO and Objaverse, rendere
 
 - To parse the camera params including extrinsics and intrinsics
   ```
+  glcam_in_cvcam = np.array([[1,0,0,0],
+                          [0,-1,0,0],
+                          [0,0,-1,0],
+                          [0,0,0,1]]).astype(float)
   with open(f'{base_dir}/camera_params/camera_params_000000.json','r') as ff:
     camera_params = json.load(ff)
   world_in_glcam = np.array(camera_params['cameraViewTransform']).reshape(4,4).T

--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,7 @@ Our training data include scenes using 3D assets from GSO and Objaverse, rendere
                           [0,-1,0,0],
                           [0,0,-1,0],
                           [0,0,0,1]]).astype(float)
+  W, H = camera_params["renderProductResolution"]
   with open(f'{base_dir}/camera_params/camera_params_000000.json','r') as ff:
     camera_params = json.load(ff)
   world_in_glcam = np.array(camera_params['cameraViewTransform']).reshape(4,4).T


### PR DESCRIPTION
add this glvcam_to_cvcam in the explanation. Took me a considerable amount of time to make sure this matrix is exactly the same as the convention. It is available under Utils.py but is better to include it explicitly here as well.