### PR TITLE
Add RTX 50 series GPU compatibility via PyTorch 2.7 and CUDA 12.8

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -43,7 +43,7 @@ try:
 except:
   kornia = None
 try:
-  import mycpp.build.mycpp as mycpp
+  import mycpp
 except:
   mycpp = None
 try:

--- a/bundlesdf/mycuda/common.cu
+++ b/bundlesdf/mycuda/common.cu
@@ -117,7 +117,7 @@ at::Tensor sampleRaysUniformOccupiedVoxels(const at::Tensor z_in_out,  const at:
   const int threadx = 32;
   const int thready = 32;
 
-  AT_DISPATCH_FLOATING_TYPES(z_in_out.type(), "sample_rays_uniform_occupied_voxels_kernel", ([&]
+  AT_DISPATCH_FLOATING_TYPES(z_in_out.scalar_type(), "sample_rays_uniform_occupied_voxels_kernel", ([&]
   {
     sample_rays_uniform_occupied_voxels_kernel<scalar_t><<<{divCeil(N_rays,threadx),divCeil(N_samples,thready)}, {threadx,thready}>>>(z_sampled.packed_accessor32<scalar_t,2,torch::RestrictPtrTraits>(),z_in_out.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),z_vals.packed_accessor32<scalar_t,2,torch::RestrictPtrTraits>());
   }));
@@ -159,7 +159,7 @@ at::Tensor postprocessOctreeRayTracing(const at::Tensor ray_index, const at::Ten
   at::Tensor depths_in_out_padded = at::zeros({N_rays,max_intersections,2}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA, 0).requires_grad(false));
   dim3 threads = {256};
   dim3 blocks = {divCeil(n_unique_ids,threads.x)};
-  AT_DISPATCH_FLOATING_TYPES(depth_in_out.type(), "postprocessOctreeRayTracingKernel", ([&]
+  AT_DISPATCH_FLOATING_TYPES(depth_in_out.scalar_type(), "postprocessOctreeRayTracingKernel", ([&]
   {
     postprocessOctreeRayTracingKernel<scalar_t><<<blocks,threads>>>(ray_index.packed_accessor32<long,1,torch::RestrictPtrTraits>(), depth_in_out.packed_accessor32<scalar_t,2,torch::RestrictPtrTraits>(), unique_intersect_ray_ids.packed_accessor32<long,1,torch::RestrictPtrTraits>(), start_poss.packed_accessor32<long,1,torch::RestrictPtrTraits>(), depths_in_out_padded.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>());
   }));
@@ -265,7 +265,7 @@ void rayColorToTextureImageCUDA(const at::Tensor &F, const at::Tensor &V, const 
   dim3 threads = {512};
   dim3 blocks = {divCeil(int(hit_locations.sizes()[0]),threads.x)};
 
-  AT_DISPATCH_FLOATING_TYPES(V.type(), "rayColorToTextureImageKernel", ([&]
+  AT_DISPATCH_FLOATING_TYPES(V.scalar_type(), "rayColorToTextureImageKernel", ([&]
   {
     rayColorToTextureImageKernel<scalar_t><<<blocks,threads>>>(F.packed_accessor32<long,2,torch::RestrictPtrTraits>(), V.packed_accessor32<scalar_t,2,torch::RestrictPtrTraits>(), hit_locations.packed_accessor32<scalar_t,2,torch::RestrictPtrTraits>(), hit_face_ids.packed_accessor32<long,1,torch::RestrictPtrTraits>(), uvs_tex.packed_accessor32<scalar_t,2,torch::RestrictPtrTraits>(), uvs.packed_accessor32<scalar_t,2,torch::RestrictPtrTraits>());
   }));

--- a/bundlesdf/mycuda/setup.py
+++ b/bundlesdf/mycuda/setup.py
@@ -15,8 +15,8 @@ from torch.utils.cpp_extension import load
 code_dir = os.path.dirname(os.path.realpath(__file__))
 
 
-nvcc_flags = ['-Xcompiler', '-O3', '-std=c++14', '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__']
-c_flags = ['-O3', '-std=c++14']
+nvcc_flags = ['-Xcompiler', '-O3', '-std=c++17', '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__']
+c_flags = ['-O3', '-std=c++17']
 
 setup(
     name='common',

--- a/mycpp/src/app/pybind_api.cpp
+++ b/mycpp/src/app/pybind_api.cpp
@@ -23,7 +23,7 @@ namespace py = pybind11;
 //@dist_diff: unit is meter
 vectorMatrix4f cluster_poses(float angle_diff, float dist_diff, const vectorMatrix4f &poses_in, const vectorMatrix4f &symmetry_tfs)
 {
-  printf("num original candidates = %d\n",poses_in.size());
+  printf("num original candidates = %zu\n",poses_in.size());
   vectorMatrix4f poses_out;
   poses_out.push_back(poses_in[0]);
 
@@ -63,7 +63,7 @@ vectorMatrix4f cluster_poses(float angle_diff, float dist_diff, const vectorMatr
     }
   }
 
-  printf("num of pose after clustering: %d\n",poses_out.size());
+  printf("num of pose after clustering: %zu\n",poses_out.size());
   return poses_out;
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
-# PyTorch 2.1.1
---extra-index-url https://download.pytorch.org/whl/cu118
-# torch==2.1.1+cu118
-# torchvision==0.16.1+cu118
-torch==2.0.0+cu118
-torchvision==0.15.1+cu118
-torchaudio==2.0.1+cu118
+# PyTorch 2.7 for RTX 5080 CUDA 12.8 compatibility
+--extra-index-url https://download.pytorch.org/whl/cu128
+torch==2.7.1+cu128
+torchaudio==2.7.1+cu128
+torchvision==0.22.1+cu128
 
 
 # JupyterLab


### PR DESCRIPTION
This PR addresses multiple compatibility issues that prevent FoundationPose from building and running on RTX 50 series (sm_120 architecture) GPUs with modern PyTorch versions.

  - PyTorch API Updates: Replaced deprecated .type() calls with .scalar_type() in 3 locations in `bundlesdf/mycuda/common.cu` to fix compilation errors with PyTorch 2.7+
  - C++ Standard Upgrade: Updated from C++14 to C++17 in `bundlesdf/mycuda/setup.py` to meet modern PyTorch requirements
  - Format String Fixes: Fixed printf format warnings in `mycpp/src/app/pybind_api.cpp` by changing `%d` to `%zu` for `size_t` values
  - PyTorch Version Update: Updated `requirements.txt` to use PyTorch 2.7.1 with CUDA 12.8 for RTX 50 series compatibility
  - Import Path Fix: Corrected `mycpp` import path in `Utils.py` from `mycpp.build.mycpp` to `mycpp`
  - RTX 50 Series Guide: Added comprehensive setup instructions for RTX 50 series GPUs in `readme.md`
  - Troubleshooting Section: Detailed common build and runtime issues with specific error messages and solutions